### PR TITLE
Change regex for parsing table 4a

### DIFF
--- a/workflows/rivm_pdf/parse_pdf_table.py
+++ b/workflows/rivm_pdf/parse_pdf_table.py
@@ -24,9 +24,9 @@ def parse_onderliggende_a(content):
         r"Niet vermeld\n\n"
         r"\%\n\n"
         r"(\d+)\n"
-        r"(\d+) \([0-9\.]+\)\n"
-        r"(\d+) \([0-9\.]+\)\n"
-        r"(\d+) \([0-9\.]+\)",
+        r"(\d+) [0-9\.]+\n"
+        r"(\d+) [0-9\.]+\n"
+        r"(\d+) [0-9\.]+",
         content
     )
     assert len(onderliggend_a[0]) == 4


### PR DESCRIPTION
Percentages of table 4a are now noted without brackets:
4786 69.8
Instead of:
4786 (69.8)