### PR TITLE
Update cron job to update at 2 PM (GMT+2)

### DIFF
--- a/.github/workflows/download_datasets.yml
+++ b/.github/workflows/download_datasets.yml
@@ -1,7 +1,7 @@
 name: "Download datasets"
 on:
   schedule:
-    - cron:  '*/15 14-16 * * *'
+    - cron:  '*/15 12-14 * * *'
 
 jobs:
   download-rivm-geo:

--- a/.github/workflows/download_datasets.yml
+++ b/.github/workflows/download_datasets.yml
@@ -1,7 +1,7 @@
 name: "Download datasets"
 on:
   schedule:
-    - cron:  '*/15 12-14 * * *'
+    - cron:  '20,50 12-15 * * *'
 
 jobs:
   download-rivm-geo:


### PR DESCRIPTION
According to [RIVM COVID-19 Dashboard](https://data.rivm.nl/covid-19/), data sets get updated at 14:15 local time, which is at 12:15 GMT time. 

This change would start the cron job to download latest data sets 2 hour earlier to get the latest data as soon as it is available.