### PR TITLE
Fix push Github Action

### DIFF
--- a/.github/workflows/download_datasets.yml
+++ b/.github/workflows/download_datasets.yml
@@ -32,6 +32,7 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
         continue-on-error: true
   download-lcps:
     name: Download LCPS
@@ -60,6 +61,7 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
         continue-on-error: true
   download-dashboard:
     runs-on: ubuntu-latest
@@ -86,6 +88,7 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
         continue-on-error: true
   download-gov-measures:
     runs-on: ubuntu-latest
@@ -112,5 +115,6 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
         continue-on-error: true
 

--- a/.github/workflows/download_nice.yml
+++ b/.github/workflows/download_nice.yml
@@ -30,4 +30,5 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
         continue-on-error: true


### PR DESCRIPTION
Pipelines are broken due to a sudden change in one of our dependencies https://github.com/ad-m/github-push-action/issues/68, https://github.com/ad-m/github-push-action/pull/69. 